### PR TITLE
Refactor scripts into mosaic_sim package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# 2D_Mosaic_Sim
+# mosaic_sim
+
+This package provides utilities for simulating rocking curves and mosaic
+intensity distributions for Bi₂Se₃ crystals.  Two command line scripts are
+included:
+
+- `simulate_detector.py` – 3‑panel rocking‑curve figure
+- `simulate_mosaic.py`  – dynamic Bragg‑sphere animation
+
+Both rely on the shared `mosaic_sim` package which exposes physical constants,
+geometry helpers and intensity kernels.

--- a/mosaic_sim/__init__.py
+++ b/mosaic_sim/__init__.py
@@ -1,0 +1,14 @@
+"""Public API for mosaic_sim."""
+from .constants import λ, a_hex, c_hex, K_MAG, d_hex
+from .geometry import sphere, rot_x, intersection_circle
+from .intensity import cap_intensity, belt_intensity, mosaic_intensity
+from .detector import build_detector_figure
+from .animation import build_animation
+
+__all__ = [
+    "λ", "a_hex", "c_hex", "K_MAG", "d_hex",
+    "sphere", "rot_x", "intersection_circle",
+    "cap_intensity", "belt_intensity", "mosaic_intensity",
+    "build_detector_figure", "build_animation",
+]
+

--- a/mosaic_sim/animation.py
+++ b/mosaic_sim/animation.py
@@ -1,0 +1,130 @@
+"""Dynamic Bragg-sphere rotation animation."""
+import math
+import numpy as np
+import plotly.graph_objects as go
+
+from .constants import a_hex, c_hex, K_MAG, d_hex
+from .geometry import sphere, rot_x, intersection_circle
+from .intensity import mosaic_intensity
+
+
+def build_animation(H=0, K=0, L=1,
+                    sigma=np.deg2rad(0.8),
+                    gamma=np.deg2rad(5.0),
+                    eta=0.5):
+    d_hkl = d_hex(H, K, L, a_hex, c_hex)
+    G_MAG = 2 * math.pi / d_hkl
+
+    phi, theta = np.meshgrid(np.linspace(0, math.pi, 100),
+                             np.linspace(0, 2*math.pi, 200))
+    Ew_x, Ew_y, Ew_z = sphere(K_MAG, phi, theta, (0, K_MAG, 0))
+    B0_x, B0_y, B0_z = sphere(G_MAG, phi, theta)
+
+    I_surface = mosaic_intensity(B0_x, B0_y, B0_z, H, K, L, sigma, gamma, eta)
+
+    ring_x, ring_y, ring_z = intersection_circle(G_MAG, K_MAG, K_MAG)
+    k_tail = np.array([0.0, K_MAG, 0.0])
+    k_head = k_tail * 0.25
+    cone_vec = -k_head
+    R_MAX = max(G_MAG, K_MAG)
+
+    def dyn_state(th):
+        Bx, By, Bz = rot_x(B0_x, B0_y, B0_z, -th)
+        r_arc = 0.5
+        t_arc = np.linspace(0, th, 50)
+        ax = np.zeros_like(t_arc)
+        ay = -r_arc*np.cos(t_arc)
+        az = -r_arc*np.sin(t_arc)
+        theta_lab = (0, -r_arc*math.cos(th/2), -r_arc*math.sin(th/2))
+        return dict(Bx=Bx, By=By, Bz=Bz, Arc=(ax, ay, az), Theta_lab=theta_lab)
+
+    fig = go.Figure()
+
+    bragg = go.Surface(x=B0_x, y=B0_y, z=B0_z,
+                       surfacecolor=I_surface,
+                       colorscale=[[0, "rgba(128,128,128,0.25)"],
+                                   [1, "rgba(255,0,0,1)"]],
+                       showscale=True,
+                       colorbar=dict(title="Mosaic<br>Intensity"),
+                       name=f"Bragg sphere {'cap' if H==0 and K==0 else 'band'}")
+    fig.add_trace(bragg); bragg_idx = len(fig.data) - 1
+
+    fig.add_trace(go.Surface(x=Ew_x, y=Ew_y, z=Ew_z,
+                             opacity=0.3, colorscale="Blues",
+                             showscale=False, name="Ewald sphere"))
+    fig.add_trace(go.Scatter3d(x=ring_x, y=ring_y, z=ring_z,
+                               mode="lines",
+                               line=dict(color="green", width=5),
+                               name="2θB ring"))
+    fig.add_trace(go.Scatter3d(x=[k_tail[0], k_head[0]], y=[k_tail[1], k_head[1]], z=[k_tail[2], k_head[2]],
+                               mode="lines", line=dict(color="black", width=5), name="kᵢ"))
+    fig.add_trace(go.Cone(x=[k_head[0]], y=[k_head[1]], z=[k_head[2]],
+                          u=[cone_vec[0]], v=[cone_vec[1]], w=[cone_vec[2]],
+                          anchor="tail", sizemode="absolute", sizeref=0.2,
+                          colorscale=[[0, "black"], [1, "black"]], showscale=False))
+
+    st0 = dyn_state(np.deg2rad(5))
+    fig.add_trace(go.Scatter3d(x=st0["Arc"][0], y=st0["Arc"][1], z=st0["Arc"][2],
+                               mode="lines",
+                               line=dict(color="purple", width=3, dash="dash")))
+    fig.add_trace(go.Scatter3d(x=[st0["Theta_lab"][0]], y=[st0["Theta_lab"][1]], z=[st0["Theta_lab"][2]], mode="text", text=["θᵢ"], showlegend=False))
+    fig.add_trace(go.Scatter3d(x=[0], y=[K_MAG/2], z=[0], mode="text", text=["kᵢ"], showlegend=False))
+
+    for xyz in [([-R_MAX, R_MAX], [0,0], [0,0]),
+                ([0,0], [-R_MAX, 2*R_MAX], [0,0]),
+                ([0,0], [0,0], [-R_MAX, R_MAX])]:
+        fig.add_trace(go.Scatter3d(x=xyz[0], y=xyz[1], z=xyz[2],
+                                   mode="lines", showlegend=False,
+                                   line=dict(color="black", width=2, dash="dash")))
+    fig.update_layout(scene=dict(xaxis=dict(visible=False),
+                                 yaxis=dict(visible=False),
+                                 zaxis=dict(visible=False),
+                                 bgcolor="rgba(0,0,0,0)"),
+                      paper_bgcolor="rgba(0,0,0,0)",
+                      margin=dict(l=0, r=0, b=0, t=0))
+
+    THETA_MIN, THETA_MAX = np.deg2rad(5), np.deg2rad(30)
+    N_FRAMES = 60
+    theta_fwd = np.linspace(THETA_MIN, THETA_MAX, N_FRAMES//2, endpoint=False)
+    theta_all = np.concatenate([theta_fwd, theta_fwd[::-1]])
+
+    frames = []
+    for i, th in enumerate(theta_all):
+        st = dyn_state(th)
+        frames.append(go.Frame(name=f"f{i}",
+            data=[
+                go.Surface(x=st["Bx"], y=st["By"], z=st["Bz"],
+                           surfacecolor=I_surface,
+                           colorscale=bragg.colorscale, showscale=False),
+                go.Scatter3d(x=st["Arc"][0], y=st["Arc"][1], z=st["Arc"][2],
+                             mode="lines",
+                             line=dict(color="purple", width=3, dash="dash")),
+                go.Scatter3d(x=[st["Theta_lab"][0]], y=[st["Theta_lab"][1]], z=[st["Theta_lab"][2]], mode="text", text=["θᵢ"], showlegend=False)
+            ],
+            traces=[bragg_idx, len(fig.data)-2, len(fig.data)-1]))
+    fig.frames = frames
+
+    fig.update_layout(updatemenus=[dict(type="buttons",
+                                        direction="left", x=0.5, y=1.07, xanchor="center",
+                                        buttons=[
+                                            dict(label="▶ Play / Loop", method="animate",
+                                                 args=[None, dict(frame=dict(duration=5, redraw=True),
+                                                                  transition=dict(duration=0),
+                                                                  fromcurrent=True, mode="immediate", loop=True)]),
+                                            dict(label="■ Stop", method="animate",
+                                                 args=[[None], dict(frame=dict(duration=0, redraw=False),
+                                                                    transition=dict(duration=0),
+                                                                    mode="immediate")])])])
+
+    return fig
+
+
+def main():
+    import plotly.io as pio
+    pio.renderers.default = "browser"
+    fig = build_animation()
+    fig.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaic_sim/constants.py
+++ b/mosaic_sim/constants.py
@@ -1,0 +1,19 @@
+"""Physical constants and lattice helpers for mosaic simulations."""
+import math
+
+# Wavelength of Cu-Kα radiation in meters
+λ = 1.5406e-10
+
+# Hexagonal lattice constants for Bi₂Se₃
+a_hex = 4.143e-10
+c_hex = 28.636e-10
+
+# Magnitude of the incident wavevector |k|
+K_MAG = 2 * math.pi / λ
+
+
+def d_hex(h: int, k: int, l: int, a: float = a_hex, c: float = c_hex) -> float:
+    """Return the d-spacing for (h k l) using hexagonal parameters."""
+    return 1.0 / math.sqrt((4/3) * (h*h + h*k + k*k) / a**2 + (l / c) ** 2)
+
+__all__ = ["λ", "a_hex", "c_hex", "K_MAG", "d_hex"]

--- a/mosaic_sim/detector.py
+++ b/mosaic_sim/detector.py
@@ -1,0 +1,207 @@
+"""3-panel rocking-curve detector simulation."""
+import math
+import numpy as np
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+from .constants import a_hex, c_hex, K_MAG, d_hex
+from .geometry import sphere, rot_x, intersection_circle
+from .intensity import mosaic_intensity
+
+
+def build_detector_figure(H=0, K=0, L=12,
+                          sigma=np.deg2rad(0.8),
+                          gamma=np.deg2rad(5.0),
+                          eta=0.5):
+    """Return a Plotly Figure replicating the detector simulation."""
+    d_hkl = d_hex(H, K, L, a_hex, c_hex)
+    G_MAG = 2 * math.pi / d_hkl
+
+    def gaussian_blur(a, sigma_blur=5):
+        r = int(3 * sigma_blur)
+        k = np.exp(-0.5 * (np.arange(-r, r+1) / sigma_blur) ** 2)
+        k /= k.sum()
+        return np.convolve(a, k, mode="same")
+
+    phi, theta = np.meshgrid(np.linspace(0, math.pi, 100),
+                             np.linspace(0, 2*math.pi, 200))
+    Ew_x, Ew_y, Ew_z = sphere(K_MAG, phi, theta, (0, K_MAG, 0))
+    B0_x, B0_y, B0_z = sphere(G_MAG, phi, theta)
+
+    I_surf = mosaic_intensity(B0_x, B0_y, B0_z, H, K, L, sigma, gamma, eta)
+
+    ring_x, ring_y, ring_z = intersection_circle(G_MAG, K_MAG, K_MAG)
+    hr_x, hr_y, hr_z = ring_x, ring_y, ring_z
+    hr_t = np.linspace(0, 2*math.pi, len(hr_x))
+    mask_top = hr_z >= 0
+
+    theta_min, theta_max, N_FR = np.deg2rad(5), np.deg2rad(30), 120
+    theta_all = np.concatenate([np.linspace(theta_min, theta_max, N_FR//2, endpoint=False),
+                                np.linspace(theta_max, theta_min, N_FR//2)])
+
+    sample_ids = np.linspace(0, N_FR-1, 10, dtype=int)
+    opacity_vals = np.linspace(0.15, 1.0, 10)
+    frame_to_tail = {fid: k for k, fid in enumerate(sample_ids)}
+
+    tails, tail_idx = [], []
+    for op, idx in zip(opacity_vals, sample_ids):
+        th = theta_all[idx]
+        rx, ry, rz = rot_x(hr_x, hr_y, hr_z, th)
+        I_blur = gaussian_blur(mosaic_intensity(rx, ry, rz, H, K, L, sigma, gamma, eta), 5)
+        subset = hr_t >= 1.0
+        pk = np.argmax(I_blur * subset)
+        phi_pk = hr_t[pk]
+        dphi = hr_t - phi_pk
+        keep = subset & (np.abs(dphi) <= 1.0)
+        tails.append(go.Scatter(x=dphi[keep], y=I_blur[keep],
+                                mode="lines",
+                                line=dict(color="crimson", width=2),
+                                opacity=op, visible=False, showlegend=False))
+
+    fig = make_subplots(rows=1, cols=3,
+                        specs=[[{"type": "scene"}, {"type": "xy"}, {"type": "xy"}]],
+                        column_widths=[0.5, 0.3, 0.2],
+                        subplot_titles=("Reciprocal space",
+                                        "Detector view",
+                                        "Centered integration"))
+
+    fig.add_trace(go.Surface(x=B0_x, y=B0_y, z=B0_z,
+                             surfacecolor=I_surf,
+                             colorscale=[[0, "rgba(128,128,128,0.25)"],
+                                         [1, "rgba(255,0,0,1)"]],
+                             showscale=True,
+                             colorbar=dict(title="Mosaic<br>Intensity")), 1, 1)
+    bragg_idx = len(fig.data) - 1
+
+    fig.add_trace(go.Surface(x=Ew_x, y=Ew_y, z=Ew_z,
+                             opacity=0.3, colorscale="Blues", showscale=False), 1, 1)
+
+    fig.add_trace(go.Scatter3d(x=ring_x, y=ring_y, z=ring_z,
+                               mode="lines", line=dict(color="green", width=5)), 1, 1)
+
+    k_tail, k_head = np.zeros(3), np.array([0, K_MAG, 0])
+    fig.add_trace(go.Scatter3d(x=[0, k_head[0]], y=[0, k_head[1]], z=[0, k_head[2]],
+                               mode="lines", line=dict(color="black", width=5)), 1, 1)
+    fig.add_trace(go.Cone(x=[k_head[0]], y=[k_head[1]], z=[k_head[2]],
+                          u=[0], v=[-0.2*K_MAG], w=[0],
+                          anchor="tip", sizemode="absolute", sizeref=0.2,
+                          colorscale=[[0, "black"], [1, "black"]], showscale=False), 1, 1)
+    fig.add_trace(go.Scatter3d(x=[0], y=[K_MAG*1.05], z=[0],
+                               mode="text", text=["kᵢ"], showlegend=False), 1, 1)
+    ktext_idx = len(fig.data) - 1
+
+    G_dir = np.array([0, math.sin(theta_all[0]), math.cos(theta_all[0])])
+    G_vec = G_dir * G_MAG
+    fig.add_trace(go.Scatter3d(x=[0, G_vec[0]], y=[0, G_vec[1]], z=[0, G_vec[2]],
+                               mode="lines", line=dict(color="red", width=4)), 1, 1)
+    Gline_idx = len(fig.data) - 1
+    fig.add_trace(go.Cone(x=[G_vec[0]], y=[G_vec[1]], z=[G_vec[2]],
+                          u=[G_vec[0]*0.2], v=[G_vec[1]*0.2], w=[G_vec[2]*0.2],
+                          anchor="tip", sizemode="absolute", sizeref=0.2,
+                          colorscale=[[0, "red"], [1, "red"]], showscale=False), 1, 1)
+    Gcone_idx = len(fig.data) - 1
+    fig.add_trace(go.Scatter3d(x=[G_vec[0]*1.05], y=[G_vec[1]*1.05], z=[G_vec[2]*1.05],
+                               mode="text", text=["G"], showlegend=False), 1, 1)
+    Gtext_idx = len(fig.data) - 1
+
+    r_arc = 0.3 * K_MAG
+    u = np.linspace(0, theta_all[0], 50)
+    arc_y, arc_z = r_arc*np.cos(u), r_arc*np.sin(u)
+    fig.add_trace(go.Scatter3d(x=np.zeros_like(arc_y), y=arc_y, z=arc_z,
+                               mode="lines", line=dict(color="magenta", width=3, dash="dot")), 1, 1)
+    arc_idx = len(fig.data) - 1
+    fig.add_trace(go.Scatter3d(x=[0], y=[r_arc*np.cos(theta_all[0]/2)], z=[r_arc*np.sin(theta_all[0]/2)],
+                               mode="text", text=["θᵢ"], showlegend=False), 1, 1)
+    thetatext_idx = len(fig.data) - 1
+
+    fig.update_scenes(dict(xaxis=dict(title="x"),
+                           yaxis=dict(title="y"),
+                           zaxis=dict(title="z"),
+                           bgcolor="rgba(0,0,0,0)"), row=1, col=1)
+
+    I_blur0 = gaussian_blur(mosaic_intensity(hr_x, hr_y, hr_z, H, K, L, sigma, gamma, eta), 5)[mask_top]
+    fig.add_trace(go.Scatter(x=hr_x[mask_top], y=hr_z[mask_top],
+                             mode="markers+lines",
+                             marker=dict(size=7, color=I_blur0, colorscale="Viridis",
+                                         showscale=False, opacity=0.9),
+                             line=dict(width=3, color="grey")), 1, 2)
+    ring2d_idx = len(fig.data) - 1
+    fig.update_xaxes(visible=False, scaleanchor="y", row=1, col=2)
+    fig.update_yaxes(visible=False, row=1, col=2)
+
+    for tr in tails:
+        fig.add_trace(tr, 1, 3)
+        tail_idx.append(len(fig.data) - 1)
+    fig.update_xaxes(title="Δφ (rad, peak = 0)", range=[-1, 1], row=1, col=3)
+    fig.update_yaxes(title="Intensity", type="log", row=1, col=3)
+
+    fig.update_layout(paper_bgcolor="rgba(0,0,0,0)",
+                      plot_bgcolor="rgba(0,0,0,0)",
+                      margin=dict(l=0, r=0, b=0, t=55))
+
+    frames, vis = [], [False]*10
+    for f, th in enumerate(theta_all):
+        Bx, By, Bz = rot_x(B0_x, B0_y, B0_z, -th)
+        surf = go.Surface(x=Bx, y=By, z=Bz,
+                          surfacecolor=I_surf,
+                          colorscale=fig.data[bragg_idx].colorscale,
+                          showscale=False)
+
+        rx, ry, rz = rot_x(hr_x, hr_y, hr_z, th)
+        I_blur = gaussian_blur(mosaic_intensity(rx, ry, rz, H, K, L, sigma, gamma, eta), 5)[mask_top]
+        ring_up = go.Scatter(x=hr_x[mask_top], y=hr_z[mask_top],
+                             mode="markers+lines",
+                             marker=dict(size=7, color=I_blur, colorscale="Viridis",
+                                         showscale=False, opacity=0.9),
+                             line=dict(width=3, color="grey"))
+
+        G_dir = np.array([0, math.sin(th), math.cos(th)])
+        G_vec = G_dir * G_MAG
+        G_line = go.Scatter3d(x=[0, G_vec[0]], y=[0, G_vec[1]], z=[0, G_vec[2]],
+                               mode="lines", line=dict(color="red", width=4))
+        G_cone = go.Cone(x=[G_vec[0]], y=[G_vec[1]], z=[G_vec[2]],
+                         u=[G_vec[0]*0.2], v=[G_vec[1]*0.2], w=[G_vec[2]*0.2],
+                         anchor="tip", sizemode="absolute", sizeref=0.2,
+                         colorscale=[[0, "red"], [1, "red"]], showscale=False)
+        G_text = go.Scatter3d(x=[G_vec[0]*1.05], y=[G_vec[1]*1.05], z=[G_vec[2]*1.05],
+                              mode="text", text=["G"], showlegend=False)
+
+        u = np.linspace(0, th, 50)
+        arc_line = go.Scatter3d(x=np.zeros_like(u), y=r_arc*np.cos(u), z=r_arc*np.sin(u),
+                                mode="lines", line=dict(color="magenta", width=3, dash="dot"))
+        arc_text = go.Scatter3d(x=[0], y=[r_arc*np.cos(th/2)], z=[r_arc*np.sin(th/2)],
+                                mode="text", text=["θᵢ"], showlegend=False)
+
+        if f in frame_to_tail:
+            vis[frame_to_tail[f]] = True
+        tails_update = [go.Scatter(visible=v) for v in vis]
+
+        frames.append(go.Frame(data=[surf, ring_up, G_line, G_cone, G_text, arc_line, arc_text] + tails_update,
+                               traces=[bragg_idx, ring2d_idx, Gline_idx, Gcone_idx, Gtext_idx, arc_idx, thetatext_idx] + tail_idx))
+
+    fig.frames = frames
+
+    fig.update_layout(updatemenus=[dict(type="buttons", direction="left",
+                                        x=0.5, y=1.18, xanchor="center",
+                                        buttons=[
+                                            dict(label="▶ Play / Loop", method="animate",
+                                                 args=[None, dict(frame=dict(duration=5, redraw=True),
+                                                                  transition=dict(duration=0),
+                                                                  fromcurrent=True, mode="immediate", loop=True)]),
+                                            dict(label="■ Stop", method="animate",
+                                                 args=[[None], dict(frame=dict(duration=0, redraw=False),
+                                                                    transition=dict(duration=0),
+                                                                    mode="immediate")])])])
+
+    return fig
+
+
+def main():
+    import plotly.io as pio
+    pio.renderers.default = "browser"
+    fig = build_detector_figure()
+    fig.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaic_sim/geometry.py
+++ b/mosaic_sim/geometry.py
@@ -1,0 +1,26 @@
+"""Basic geometry helpers shared by the mosaic simulations."""
+import math
+import numpy as np
+
+__all__ = ["sphere", "rot_x", "intersection_circle"]
+
+def sphere(R: float, phi: np.ndarray, theta: np.ndarray, center=(0, 0, 0)):
+    cx, cy, cz = center
+    return (
+        cx + R * np.sin(phi) * np.cos(theta),
+        cy + R * np.sin(phi) * np.sin(theta),
+        cz + R * np.cos(phi),
+    )
+
+
+def rot_x(x: np.ndarray, y: np.ndarray, z: np.ndarray, ang: float):
+    c, s = np.cos(ang), np.sin(ang)
+    return x, c * y - s * z, s * y + c * z
+
+
+def intersection_circle(Rg: float, Re: float, d: float):
+    """Return x, y, z arrays for the Bragg/Ewald intersection circle."""
+    y0 = (d * d - Re * Re + Rg * Rg) / (2 * d)
+    r = math.sqrt(max(Rg * Rg - y0 * y0, 0.0))
+    t = np.linspace(0.0, 2 * math.pi, 400)
+    return r * np.cos(t), np.full_like(t, y0), r * np.sin(t)

--- a/mosaic_sim/intensity.py
+++ b/mosaic_sim/intensity.py
@@ -1,0 +1,36 @@
+"""Mosaic intensity kernels."""
+import math
+import numpy as np
+from numba import njit
+
+__all__ = ["cap_intensity", "belt_intensity", "mosaic_intensity"]
+
+@njit
+def cap_intensity(Qx, Qy, Qz, sigma):
+    I = np.empty_like(Qx)
+    for i in range(Qx.shape[0]):
+        for j in range(Qx.shape[1]):
+            qx, qy, qz = Qx[i, j], Qy[i, j], Qz[i, j]
+            Qmag = math.sqrt(qx*qx + qy*qy + qz*qz) or 1e-14
+            alpha = math.acos(max(-1.0, min(1.0, qz / Qmag)))
+            I[i, j] = math.exp(-0.5 * (alpha / sigma) ** 2)
+    return I / I.max()
+
+@njit
+def belt_intensity(Qx, Qy, Qz, Gx, Gy, Gz, sigma, gamma, eta):
+    I = np.empty_like(Qx)
+    Gmag = math.sqrt(Gx*Gx + Gy*Gy + Gz*Gz)
+    nu_c = math.acos(max(-1.0, min(1.0, Gz / Gmag)))
+    for i in range(Qx.shape[0]):
+        for j in range(Qx.shape[1]):
+            qz = Qz[i, j]
+            Qmag = math.sqrt(Qx[i, j]**2 + Qy[i, j]**2 + qz*qz) or 1e-14
+            nu_p = math.acos(max(-1.0, min(1.0, qz / Qmag)))
+            dnu = abs(nu_p - nu_c)
+            I[i, j] = (1 - eta) * math.exp(-dnu*dnu / (2*sigma*sigma)) + eta / (1 + (dnu / gamma)**2)
+    return I / I.max()
+
+def mosaic_intensity(Qx, Qy, Qz, H, K, L, sigma, gamma, eta):
+    if H == 0 and K == 0:
+        return cap_intensity(Qx, Qy, Qz, sigma)
+    return belt_intensity(Qx, Qy, Qz, H, K, L, sigma, gamma, eta)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "mosaic_sim"
+version = "0.1.0"
+description = "Rocking-curve and detector simulations for Bi2Se3 mosaics"
+requires-python = ">=3.11"
+dependencies = ["plotly>=6.0", "numba>=0.59", "numpy>=1.26"]
+
+[project.scripts]
+mosaic-detector = "mosaic_sim.detector:main"
+mosaic-rocking = "mosaic_sim.animation:main"

--- a/simulate_detector.py
+++ b/simulate_detector.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Command-line entry for the detector simulation."""
+from mosaic_sim.detector import main
+
+if __name__ == "__main__":
+    main()

--- a/simulate_mosaic.py
+++ b/simulate_mosaic.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Command-line entry for the Bragg-sphere animation."""
+from mosaic_sim.animation import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,10 @@
+import numpy as np
+from mosaic_sim.intensity import cap_intensity, belt_intensity
+from mosaic_sim.geometry import sphere
+
+
+def test_cap_normalisation():
+    phi, theta = np.meshgrid(np.linspace(0, np.pi, 20), np.linspace(0, 2*np.pi, 40))
+    Qx, Qy, Qz = sphere(1.0, phi, theta)
+    I = cap_intensity(Qx, Qy, Qz, np.deg2rad(0.8))
+    assert np.isclose(I.max(), 1.0)


### PR DESCRIPTION
## Summary
- add `mosaic_sim` package with constants, geometry, intensity and figure builders
- provide CLI wrappers `simulate_detector.py` and `simulate_mosaic.py`
- configure minimal `pyproject.toml`
- include a simple unit test for intensity normalisation
- update README

## Testing
- `python3 -m py_compile mosaic_sim/*.py simulate_*py`
- `pytest -q` *(fails: `pytest` not installed)*