### PR TITLE
Add pseudo-Voigt cap intensity

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -6,7 +6,7 @@ from mosaic_sim.geometry import sphere
 def test_cap_normalisation():
     phi, theta = np.meshgrid(np.linspace(0, np.pi, 20), np.linspace(0, 2*np.pi, 40))
     Qx, Qy, Qz = sphere(1.0, phi, theta)
-    I = cap_intensity(Qx, Qy, Qz, np.deg2rad(0.8))
+    I = cap_intensity(Qx, Qy, Qz, np.deg2rad(0.8), np.deg2rad(5), 0.5)
     assert np.isclose(I.max(), 1.0)
 
 def test_belt_handles_1d():


### PR DESCRIPTION
## Summary
- implement pseudo-Voigt formulation for cap intensity kernel
- adjust `mosaic_intensity` and tests for new parameters

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*
- `python - <<'PY'
import mosaic_sim.animation as anim
fig = anim.build_animation()
print('fig built', len(fig.data))
PY` *(fails: No module named 'numpy')*