### PR TITLE
Show cylinder/Ewald overlap

### DIFF
--- a/mosaic_sim/__init__.py
+++ b/mosaic_sim/__init__.py
@@ -4,7 +4,7 @@ Importing from this package exposes the key helpers for constructing geometry,
 intensity kernels and interactive Plotly figures used in the examples.
 """
 from .constants import λ, a_hex, c_hex, K_MAG, d_hex
-from .geometry import sphere, rot_x, intersection_circle
+from .geometry import sphere, rot_x, intersection_circle, intersection_cylinder_sphere
 from .intensity import cap_intensity, belt_intensity, mosaic_intensity
 from .detector import build_detector_figure
 from .animation import build_animation
@@ -12,7 +12,7 @@ from .cylinder import build_cylinder_figure
 
 __all__ = [
     "λ", "a_hex", "c_hex", "K_MAG", "d_hex",
-    "sphere", "rot_x", "intersection_circle",
+    "sphere", "rot_x", "intersection_circle", "intersection_cylinder_sphere",
     "cap_intensity", "belt_intensity", "mosaic_intensity",
     "build_detector_figure", "build_animation", "build_cylinder_figure",
 ]

--- a/mosaic_sim/cylinder.py
+++ b/mosaic_sim/cylinder.py
@@ -13,7 +13,12 @@ import numpy as np
 import plotly.graph_objects as go
 
 from .constants import a_hex, c_hex, K_MAG, d_hex
-from .geometry import sphere, rot_x, intersection_circle
+from .geometry import (
+    sphere,
+    rot_x,
+    intersection_circle,
+    intersection_cylinder_sphere,
+)
 from .intensity import mosaic_intensity
 
 __all__ = ["build_cylinder_figure", "main"]
@@ -42,8 +47,12 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
     I_surface = mosaic_intensity(B0_x, B0_y, B0_z, H, K, L,
                                  sigma, gamma, eta)
 
-    ring_x, ring_y, ring_z = intersection_circle(G_MAG, K_MAG, K_MAG)
-    gr = math.sqrt(ring_x[0] ** 2 + ring_z[0] ** 2)
+    br_x, br_y, br_z = intersection_circle(G_MAG, K_MAG, K_MAG)
+    gr = math.sqrt(br_x[0] ** 2 + br_z[0] ** 2)
+
+    cyl_line_x, cyl_line_y, cyl_line_z = intersection_cylinder_sphere(
+        gr, K_MAG, K_MAG
+    )
 
     t_cyl, z_cyl = np.meshgrid(np.linspace(0, 2 * math.pi, 60),
                                np.linspace(0, 5 * abs(gr), 60))
@@ -71,10 +80,16 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
                              colorscale=[[0, "grey"], [1, "grey"]],
                              name="Cylinder"))
 
-    fig.add_trace(go.Scatter3d(x=ring_x, y=ring_y, z=ring_z,
-                               mode="lines",
-                               line=dict(color="green", width=5),
-                               name="2θB ring"))
+    fig.add_trace(
+        go.Scatter3d(
+            x=cyl_line_x,
+            y=cyl_line_y,
+            z=cyl_line_z,
+            mode="lines",
+            line=dict(color="green", width=5),
+            name="Cylinder/Ewald overlap",
+        )
+    )
 
     k_tail = np.array([0.0, K_MAG, 0.0])
     k_head = k_tail * 0.25


### PR DESCRIPTION
## Summary
- add `intersection_cylinder_sphere` helper
- expose helper from the package
- draw cylinder/Ewald intersection line in cylinder simulator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c74777d808333b0a96fb9aa3e95fd