### PR TITLE
Fix cylinder intersection

### DIFF
--- a/mosaic_sim/cylinder.py
+++ b/mosaic_sim/cylinder.py
@@ -51,7 +51,10 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
     gr = math.sqrt(br_x[0] ** 2 + br_z[0] ** 2)
 
     cyl_line_x, cyl_line_y, cyl_line_z = intersection_cylinder_sphere(
-        gr, K_MAG, K_MAG
+        gr,
+        K_MAG,
+        K_MAG,
+        0.0,
     )
 
     t_cyl, z_cyl = np.meshgrid(np.linspace(0, 2 * math.pi, 60),
@@ -82,7 +85,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
             z=cyl_z,
             opacity=0.5,
             showscale=False,
-            colorscale=[[0, "grey"], [1, "grey"]],
+            colorscale=[[0, "rgb(255,191,0)"], [1, "rgb(255,191,0)"]],
             name="Cylinder",
         )
     )
@@ -138,7 +141,15 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
     for i, th in enumerate(theta_all):
         Bx, By, Bz = rot_x(B0_x, B0_y, B0_z, -th)
         Cx, Cy, Cz = rot_x(cyl_x, cyl_y, cyl_z, -th)
-        Lx, Ly, Lz = rot_x(cyl_line_x, cyl_line_y, cyl_line_z, -th)
+
+        # Intersection line for the rotated cylinder
+        Lx_r, Ly_r, Lz_r = intersection_cylinder_sphere(
+            gr,
+            K_MAG,
+            K_MAG * math.cos(th),
+            K_MAG * math.sin(th),
+        )
+        Lx, Ly, Lz = rot_x(Lx_r, Ly_r, Lz_r, -th)
         frames.append(
             go.Frame(
                 name=f"f{i}",
@@ -157,7 +168,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
                         z=Cz,
                         opacity=0.5,
                         showscale=False,
-                        colorscale=[[0, "grey"], [1, "grey"]],
+                        colorscale=[[0, "rgb(255,191,0)"], [1, "rgb(255,191,0)"]],
                     ),
                     go.Scatter3d(
                         x=Lx,

--- a/mosaic_sim/geometry.py
+++ b/mosaic_sim/geometry.py
@@ -72,13 +72,18 @@ def intersection_circle(Rg: float, Re: float, d: float) -> tuple[np.ndarray, np.
     return r * np.cos(t), np.full_like(t, y0), r * np.sin(t)
 
 
-def intersection_cylinder_sphere(rc: float, Re: float, d: float,
-                                 npts: int = 400) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def intersection_cylinder_sphere(
+    rc: float,
+    Re: float,
+    dy: float,
+    dz: float = 0.0,
+    npts: int = 400,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Points where a cylinder intersects a sphere.
 
     The cylinder is assumed to run along the ``qz`` axis and to be centred on
-    the origin.  ``rc`` gives its radius.  The sphere of radius ``Re`` is
-    offset along ``qy`` by ``d``.
+    the origin. ``rc`` gives its radius.  The sphere of radius ``Re`` is offset
+    along ``qy`` by ``dy`` and optionally along ``qz`` by ``dz``.
 
     Parameters
     ----------
@@ -86,8 +91,10 @@ def intersection_cylinder_sphere(rc: float, Re: float, d: float,
         Radius of the cylinder.
     Re:
         Radius of the sphere.
-    d:
+    dy:
         Offset of the sphere centre along ``qy``.
+    dz:
+        Optional offset of the sphere centre along ``qz``.
     npts:
         Number of points used to sample the intersection curve.
 
@@ -101,7 +108,7 @@ def intersection_cylinder_sphere(rc: float, Re: float, d: float,
     t = np.linspace(0.0, 2 * math.pi, npts)
     x = rc * np.cos(t)
     y = rc * np.sin(t)
-    zsq = Re * Re - d * d - rc * rc + 2 * rc * d * np.sin(t)
+    zsq = Re * Re - rc * rc - dy * dy + 2 * rc * dy * np.sin(t)
     mask = zsq >= 0
     if not np.any(mask):
         return np.array([]), np.array([]), np.array([])
@@ -112,5 +119,5 @@ def intersection_cylinder_sphere(rc: float, Re: float, d: float,
     return (
         np.concatenate([x, x[::-1]]),
         np.concatenate([y, y[::-1]]),
-        np.concatenate([z, -z[::-1]]),
+        np.concatenate([dz + z, dz - z[::-1]]),
     )


### PR DESCRIPTION
## Summary
- compute cylinder/Ewald intersection for each animation frame
- update intersection helper to allow z-offset
- color the cylinder amber

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c77d6d6e48333b7fa0cc2b589792c