### PR TITLE
Fix cylinder visibility

### DIFF
--- a/mosaic_sim/cylinder.py
+++ b/mosaic_sim/cylinder.py
@@ -32,8 +32,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
 
     Parameters mirror :func:`mosaic_sim.animation.build_animation` but the
     result is a static figure with a slider.  The radius of the cylinder
-    matches the Bragg-ring radius and extends from ``qz=0`` to
-    ``qz=5·|qz|``.
+    matches the Bragg-ring radius and spans ``qz=-4·|gr|`` to ``qz=4·|gr|``.
     """
 
     d_hkl = d_hex(H, K, L, a_hex, c_hex)
@@ -57,8 +56,9 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
         0.0,
     )
 
-    t_cyl, z_cyl = np.meshgrid(np.linspace(0, 2 * math.pi, 60),
-                               np.linspace(0, 5 * abs(gr), 60))
+    t_cyl, z_cyl = np.meshgrid(
+        np.linspace(0, 2 * math.pi, 60), np.linspace(-4.0 * abs(gr), 4.0 * abs(gr), 60)
+    )
     cyl_x = gr * np.cos(t_cyl)
     cyl_y = gr * np.sin(t_cyl)
     cyl_z = z_cyl


### PR DESCRIPTION
## Summary
- clarify cylinder extent in docstring
- scale cylinder z-range with Bragg-ring radius so it spans from -4*|gr| to 4*|gr|

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c79b369d8833386a71b359859bcfe