### PR TITLE
Add far-field flat detector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Run the examples directly:
 python simulate_detector.py    # Open the static detector figure
 python simulate_mosaic.py      # Launch the interactive animation
 python simulate_cylinder.py    # Cylinder intersection with slider
+python simulate_screen.py      # Pattern on a distant flat detector
 ```
 
 When installed as a package the scripts are available as console entry points
-`mosaic-detector`, `mosaic-rocking` and `mosaic-cylinder`.
+`mosaic-detector`, `mosaic-rocking`, `mosaic-cylinder` and `mosaic-screen`.

--- a/mosaic_sim/__init__.py
+++ b/mosaic_sim/__init__.py
@@ -7,6 +7,7 @@ from .constants import λ, a_hex, c_hex, K_MAG, d_hex
 from .geometry import sphere, rot_x, intersection_circle, intersection_cylinder_sphere
 from .intensity import cap_intensity, belt_intensity, mosaic_intensity
 from .detector import build_detector_figure
+from .screen import build_screen_figure
 from .animation import build_animation
 from .cylinder import build_cylinder_figure
 
@@ -14,6 +15,7 @@ __all__ = [
     "λ", "a_hex", "c_hex", "K_MAG", "d_hex",
     "sphere", "rot_x", "intersection_circle", "intersection_cylinder_sphere",
     "cap_intensity", "belt_intensity", "mosaic_intensity",
-    "build_detector_figure", "build_animation", "build_cylinder_figure",
+    "build_detector_figure", "build_screen_figure",
+    "build_animation", "build_cylinder_figure",
 ]
 

--- a/mosaic_sim/screen.py
+++ b/mosaic_sim/screen.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+"""Far-field detector pattern for the mosaic simulation."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import plotly.graph_objects as go
+
+from .constants import a_hex, c_hex, K_MAG, d_hex
+from .geometry import intersection_circle
+from .intensity import mosaic_intensity
+
+__all__ = ["build_screen_figure", "main"]
+
+
+def build_screen_figure(
+    H: int = 0,
+    K: int = 0,
+    L: int = 12,
+    sigma: float = np.deg2rad(0.8),
+    gamma: float = np.deg2rad(5.0),
+    eta: float = 0.5,
+    det_y: float = 1.0e4,
+) -> go.Figure:
+    """Return a Plotly figure of the pattern on a distant detector."""
+
+    d_hkl = d_hex(H, K, L, a_hex, c_hex)
+    G_MAG = 2 * math.pi / d_hkl
+
+    rx, ry, rz = intersection_circle(G_MAG, K_MAG, K_MAG)
+    I_ring = mosaic_intensity(rx, ry, rz, H, K, L, sigma, gamma, eta)
+
+    scale = det_y / ry
+    x_det = rx * scale
+    z_det = rz * scale
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=x_det,
+            y=z_det,
+            mode="markers",
+            marker=dict(
+                color=I_ring,
+                colorscale="Viridis",
+                size=6,
+                showscale=True,
+                colorbar=dict(title="Intensity"),
+            ),
+        )
+    )
+    fig.update_xaxes(title="x", scaleanchor="y")
+    fig.update_yaxes(title="z")
+    fig.update_layout(
+        title=f"Flat detector at y={det_y}",
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        margin=dict(l=0, r=0, b=0, t=30),
+    )
+    return fig
+
+
+def main() -> None:
+    """Launch the far-field detector figure."""
+
+    import plotly.io as pio
+
+    pio.renderers.default = "browser"
+    fig = build_screen_figure()
+    fig.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,4 @@ dependencies = ["plotly>=6.0", "numba>=0.59", "numpy>=1.26"]
 mosaic-detector = "mosaic_sim.detector:main"
 mosaic-rocking = "mosaic_sim.animation:main"
 mosaic-cylinder = "mosaic_sim.cylinder:main"
+mosaic-screen = "mosaic_sim.screen:main"

--- a/simulate_screen.py
+++ b/simulate_screen.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Command-line entry for the far-field detector example."""
+from mosaic_sim.screen import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new example to place a flat detector far along the y-axis
- export `build_screen_figure` and expose it via a new `mosaic-screen` CLI
- document the new script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c7d820fe88333aa24d246bef6a87b