### PR TITLE
Add live cylinder Dash app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Run the examples directly:
 python simulate_detector.py    # Open the static detector figure
 python simulate_mosaic.py      # Launch the interactive animation
 python simulate_cylinder.py    # Cylinder intersection with slider
+python simulate_cylinder_live.py  # Update H, K, L interactively
 python simulate_screen.py      # Pattern on a distant flat detector
 ```
 
 When installed as a package the scripts are available as console entry points
-`mosaic-detector`, `mosaic-rocking`, `mosaic-cylinder` and `mosaic-screen`.
+`mosaic-detector`, `mosaic-rocking`, `mosaic-cylinder`, `mosaic-cylinder-live` and `mosaic-screen`.

--- a/mosaic_sim/cylinder.py
+++ b/mosaic_sim/cylinder.py
@@ -21,7 +21,7 @@ from .geometry import (
 )
 from .intensity import mosaic_intensity
 
-__all__ = ["build_cylinder_figure", "main"]
+__all__ = ["build_cylinder_figure", "main", "dash_main"]
 
 
 def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
@@ -434,6 +434,47 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
     fig.update_layout(sliders=sliders, updatemenus=updatemenus)
 
     return fig
+
+
+def dash_main() -> None:
+    """Launch a Dash app allowing live Miller index updates."""
+
+    import dash
+    from dash import dcc, html
+    from dash.dependencies import Input, Output
+
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            dcc.Graph(id="cylinder-fig", figure=build_cylinder_figure()),
+            html.Div(
+                [
+                    html.Label("H"),
+                    dcc.Input(id="H", type="number", value=0, step=1),
+                    html.Label("K"),
+                    dcc.Input(id="K", type="number", value=0, step=1),
+                    html.Label("L"),
+                    dcc.Input(id="L", type="number", value=12, step=1),
+                ],
+                style={"display": "flex", "gap": "0.5rem"},
+            ),
+        ]
+    )
+
+    @app.callback(
+        Output("cylinder-fig", "figure"),
+        Input("H", "value"),
+        Input("K", "value"),
+        Input("L", "value"),
+    )
+    def update(h, k, l):  # pragma: no cover - UI callback
+        h = int(h) if h is not None else 0
+        k = int(k) if k is not None else 0
+        l = int(l) if l is not None else 0
+        return build_cylinder_figure(h, k, l)
+
+    app.run_server(debug=False)
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,11 @@ name = "mosaic_sim"
 version = "0.1.0"
 description = "Rocking-curve and detector simulations for Bi2Se3 mosaics"
 requires-python = ">=3.11"
-dependencies = ["plotly>=6.0", "numba>=0.59", "numpy>=1.26"]
+dependencies = ["plotly>=6.0", "numba>=0.59", "numpy>=1.26", "dash>=2.0"]
 
 [project.scripts]
 mosaic-detector = "mosaic_sim.detector:main"
 mosaic-rocking = "mosaic_sim.animation:main"
 mosaic-cylinder = "mosaic_sim.cylinder:main"
 mosaic-screen = "mosaic_sim.screen:main"
+mosaic-cylinder-live = "mosaic_sim.cylinder:dash_main"

--- a/simulate_cylinder_live.py
+++ b/simulate_cylinder_live.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Command-line entry for the live cylinder Dash app."""
+from mosaic_sim.cylinder import dash_main
+
+if __name__ == "__main__":
+    dash_main()


### PR DESCRIPTION
## Summary
- allow real-time HKL updates for cylinder figure via new Dash interface
- expose new entry point `mosaic-cylinder-live`
- document new script in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c86d013a8833389be3dfef62a4723