### PR TITLE
Use constants for Cu-Kα and PbI₂ 2H in mono simulator

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Quick helper to evaluate PbI₂ Bragg angles with Cu-Kα radiation."""
+
+import argparse
+import math
+
+from mosaic_sim.constants import (
+    CU_K_ALPHA_WAVELENGTH,
+    PBI2_2H_A_HEX,
+    PBI2_2H_C_HEX,
+    d_hex,
+)
+
+
+def bragg_two_theta(h: int, k: int, l: int) -> tuple[float, float]:
+    """Return (d, 2θ°) for the given (h k l) in 2H PbI₂."""
+    d_spacing = d_hex(h, k, l, a=PBI2_2H_A_HEX, c=PBI2_2H_C_HEX)
+    theta = math.asin(CU_K_ALPHA_WAVELENGTH / (2 * d_spacing))
+    return d_spacing, math.degrees(2 * theta)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute the d-spacing and 2θ position of a PbI₂ (h k l) reflection "
+            "for Cu-Kα radiation."
+        )
+    )
+    parser.add_argument("h", type=int, nargs="?", default=0, help="H Miller index")
+    parser.add_argument("k", type=int, nargs="?", default=0, help="K Miller index")
+    parser.add_argument("l", type=int, nargs="?", default=2, help="L Miller index")
+    args = parser.parse_args()
+
+    d_spacing, two_theta = bragg_two_theta(args.h, args.k, args.l)
+    print(
+        f"(h k l)=({args.h} {args.k} {args.l}) in 2H PbI₂: "
+        f"d = {d_spacing * 1e10:.4f} Å, 2θ = {two_theta:.2f}° "
+        f"(λ = {CU_K_ALPHA_WAVELENGTH * 1e10:.4f} Å)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mosaic_sim/constants.py
+++ b/mosaic_sim/constants.py
@@ -2,18 +2,34 @@
 import math
 
 # Wavelength of Cu-Kα radiation in meters
-λ = 1.5406e-10
+CU_K_ALPHA_WAVELENGTH = 1.5406e-10
 
 # Hexagonal lattice constants for Bi₂Se₃
 a_hex = 4.143e-10
 c_hex = 28.636e-10
 
+# Hexagonal lattice constants for 2H PbI₂ (in meters)
+PBI2_2H_A_HEX = 4.557e-10
+PBI2_2H_C_HEX = 6.979e-10
+
 # Magnitude of the incident wavevector |k|
-K_MAG = 2 * math.pi / λ
+K_MAG = 2 * math.pi / CU_K_ALPHA_WAVELENGTH
 
 
 def d_hex(h: int, k: int, l: int, a: float = a_hex, c: float = c_hex) -> float:
     """Return the d-spacing for (h k l) using hexagonal parameters."""
     return 1.0 / math.sqrt((4/3) * (h*h + h*k + k*k) / a**2 + (l / c) ** 2)
 
-__all__ = ["λ", "a_hex", "c_hex", "K_MAG", "d_hex"]
+# Backwards compatibility alias for existing scripts
+λ = CU_K_ALPHA_WAVELENGTH
+
+__all__ = [
+    "CU_K_ALPHA_WAVELENGTH",
+    "PBI2_2H_A_HEX",
+    "PBI2_2H_C_HEX",
+    "λ",
+    "a_hex",
+    "c_hex",
+    "K_MAG",
+    "d_hex",
+]


### PR DESCRIPTION
## Summary
- add explicit constants for Cu-Kα wavelength and 2H PbI₂ lattice parameters
- provide mono_simulator utility that calculates PbI₂ Bragg positions using the shared constants

## Testing
- python -m compileall mosaic_sim mono_simulator.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693892a6d13883338c16b4f4401fde07)