### PR TITLE
Filter single-crystal peaks to even (h,k,l) indices

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -157,8 +157,10 @@ def build_mono_figure(
 
     lattice_points = _reciprocal_points(lattice_indices)
     nonzero_mask = ~np.all(lattice_indices == 0, axis=1)
-    lattice_indices = lattice_indices[nonzero_mask]
-    lattice_points = lattice_points[nonzero_mask]
+    even_mask = np.all(lattice_indices % 2 == 0, axis=1)
+    lattice_mask = nonzero_mask & even_mask
+    lattice_indices = lattice_indices[lattice_mask]
+    lattice_points = lattice_points[lattice_mask]
 
     g_magnitudes = np.linalg.norm(lattice_points, axis=1)
     rounded_g = np.round(g_magnitudes, 6)


### PR DESCRIPTION
### Motivation
- Restrict plotted single-crystal reciprocal lattice points to even Miller indices so only peaks with even `h`, `k`, and `l` are shown.

### Description
- In `mono_simulator.py` (inside `build_mono_figure`) added `even_mask = np.all(lattice_indices % 2 == 0, axis=1)` and combined it with the existing `nonzero_mask` into `lattice_mask`, then applied `lattice_mask` to `lattice_indices` and `lattice_points` before further processing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd04e6e3c8333ae681981b411db7b)