### PR TITLE
Scale mono lattice markers by depth

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -55,8 +55,11 @@ ARC_RADIUS = 0.6
 RING_POINT_MARKER_SIZE = 14.0
 RING_INTERSECTION_MARKER_SIZE = 18.0
 CYLINDER_POINT_MARKER_SIZE = 12.0
-LATTICE_POINT_MARKER_SIZE = 13.0
+LATTICE_POINT_MARKER_SIZE_MIN = 9.0
+LATTICE_POINT_MARKER_SIZE_MAX = 18.0
 HIT_MARKER_SIZE = 26.0
+HIT_MARKER_SIZE_MIN = 20.0
+HIT_MARKER_SIZE_MAX = 32.0
 HIT_COLOR = "#e60073"
 
 
@@ -190,6 +193,12 @@ def build_mono_figure(
     lattice_indices = lattice_indices[lattice_mask]
     lattice_points = lattice_points[lattice_mask]
 
+    lattice_distances = np.linalg.norm(lattice_points - CAMERA_EYE, axis=1)
+    lattice_min_dist = float(np.min(lattice_distances)) if lattice_distances.size else 0.0
+    lattice_max_dist = float(np.max(lattice_distances)) if lattice_distances.size else 1.0
+    lattice_range = max(lattice_max_dist - lattice_min_dist, 1e-6)
+    lattice_depth_scale = 1.0 - (lattice_distances - lattice_min_dist) / lattice_range
+
     g_magnitudes = np.linalg.norm(lattice_points, axis=1)
     rounded_g = np.round(g_magnitudes, 6)
     unique_g = np.unique(rounded_g)
@@ -291,7 +300,15 @@ def build_mono_figure(
         distances = np.linalg.norm(lattice_points - center, axis=1)
         inside_mask = distances < (K_MAG_PLOT - 1e-3)
         inside_mask &= ~hit_mask
-        sizes = np.where(hit_mask, HIT_MARKER_SIZE, LATTICE_POINT_MARKER_SIZE)
+        base_sizes = (
+            LATTICE_POINT_MARKER_SIZE_MIN
+            + lattice_depth_scale * (LATTICE_POINT_MARKER_SIZE_MAX - LATTICE_POINT_MARKER_SIZE_MIN)
+        )
+        hit_sizes = (
+            HIT_MARKER_SIZE_MIN
+            + lattice_depth_scale * (HIT_MARKER_SIZE_MAX - HIT_MARKER_SIZE_MIN)
+        )
+        sizes = np.where(hit_mask, hit_sizes, base_sizes)
         outside_color = _rgba(LATTICE_POINT_COLOR, LATTICE_POINT_OPACITY)
         inside_color = _rgba(LATTICE_POINT_COLOR, LATTICE_POINT_IN_SPHERE_OPACITY)
         hit_color = _rgba(HIT_COLOR, LATTICE_POINT_OPACITY)


### PR DESCRIPTION
### Motivation
- Make reciprocal-lattice points in the single-crystal mono simulator appear larger when nearer the camera and smaller when farther away while preserving consistent visual size across zooms.

### Description
- Add configurable min/max sizes for lattice and hit markers via `LATTICE_POINT_MARKER_SIZE_MIN`, `LATTICE_POINT_MARKER_SIZE_MAX`, `HIT_MARKER_SIZE_MIN`, and `HIT_MARKER_SIZE_MAX`.
- Compute distances from `CAMERA_EYE` for each lattice point and derive a `lattice_depth_scale` to map depth to a 0..1 scale.
- Use the depth scale to compute per-point `base_sizes` and `hit_sizes` and apply these to the lattice marker trace so closer points render larger.
- Keep hit/inside/outside color logic unchanged while only modifying marker sizing behavior.

### Testing
- Generated a low-quality figure with `build_mono_figure(low_quality=True)` and rendered the interactive page via `build_interactive_page(fig, context)`, which wrote `mono_preview.html` successfully. 
- Launched a simple HTTP server and captured a screenshot of the produced page using Playwright, producing `artifacts/mono_preview.png` successfully. 
- No unit tests were modified or added; visual output was validated by the generated preview and screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696feaddced4833380edc2b66a1635e0)