### PR TITLE
Hide powder reciprocal-point markers in mono simulator views

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -620,7 +620,6 @@ def build_mono_figure(
         zip(
             g_ring_indices,
             g_ring_intersection_indices,
-            g_ring_point_indices,
             strict=True,
         )
     )
@@ -835,7 +834,6 @@ def build_mono_figure(
             g_cylinder_indices,
             g_cylinder_intersection_indices,
             g_cylinder_ring_indices,
-            g_cylinder_point_indices,
             strict=True,
         )
     )
@@ -898,10 +896,17 @@ def build_mono_figure(
         g_related = g_sphere_indices + g_circle_indices + g_point_indices
         ring_related = [idx for group in g_ring_groups for idx in group]
         cylinder_related = [idx for group in g_cylinder_groups for idx in group]
+        powder_point_indices = {
+            *g_point_indices,
+            *g_ring_point_indices,
+            *g_cylinder_point_indices,
+        }
         vis: list[bool] = []
         for idx in range(len(fig.data)):
             if idx in base_indices:
                 vis.append(True)
+            elif idx in powder_point_indices:
+                vis.append(False)
             elif idx in lattice_related:
                 vis.append(mode == "lattice")
             elif idx in g_related:
@@ -928,21 +933,15 @@ def build_mono_figure(
 
     g_mask_default = [i == 0 for i in range(len(g_sphere_indices))]
     g_mask_default.extend([i == 0 for i in range(len(g_circle_indices))])
-    g_mask_default.extend([i == 0 for i in range(len(g_point_indices))])
+    g_mask_default.extend([False for _ in range(len(g_point_indices))])
     lattice_visibility = _mode_visibility("lattice")
     g_sphere_visibility = _mode_visibility("g_spheres", g_mask_default)
     g_ring_mask_default = [True for _ in g_ring_groups]
     g_ring_visibility = _mode_visibility("g_rings", ring_mask=g_ring_mask_default)
-    for idx in g_ring_point_indices:
-        g_ring_visibility[idx] = True
     g_cylinder_mask_default = [i == 0 for i in range(len(g_cylinder_groups))]
     g_cylinder_visibility = _mode_visibility(
         "g_cylinders", cylinder_mask=g_cylinder_mask_default
     )
-    for idx in g_cylinder_point_indices:
-        g_cylinder_visibility[idx] = g_cylinder_visibility[idx] or g_cylinder_mask_default[
-            next(pos for pos, group in enumerate(g_cylinder_groups) if idx in group)
-        ]
 
     def _two_theta_str(g_mag: float) -> str:
         ratio = g_mag / (2.0 * K_MAG_PLOT)
@@ -952,13 +951,12 @@ def build_mono_figure(
         return f"{2.0 * math.degrees(math.asin(ratio)):.2f}°"
 
     g_two_thetas = [_two_theta_str(val) for val in unique_g]
-    g_group_indices = list(zip(g_sphere_indices, g_circle_indices, g_point_indices, strict=True))
+    g_group_indices = list(zip(g_sphere_indices, g_circle_indices, strict=True))
     g_cylinder_group_indices = list(
         zip(
             g_cylinder_indices,
             g_cylinder_intersection_indices,
             g_cylinder_ring_indices,
-            g_cylinder_point_indices,
             strict=True,
         )
     )
@@ -1159,15 +1157,19 @@ def build_mono_figure(
     return fig, context
 
 
-def _selector_checkbox_html(g_values: list[float], group_indices: list[tuple[int, int, int]], two_thetas: list[str]) -> str:
+def _selector_checkbox_html(
+    g_values: list[float],
+    group_indices: list[tuple[int, int]],
+    two_thetas: list[str],
+) -> str:
     lines = ["<div id=\"g-selector\">"]
-    for i, (g_val, (sphere_idx, circle_idx, points_idx), two_theta) in enumerate(
+    for i, (g_val, (sphere_idx, circle_idx), two_theta) in enumerate(
         zip(g_values, group_indices, two_thetas, strict=True)
     ):
         checked = "checked" if i == 0 else ""
         lines.append(
             f'<label class="g-option"><input class="g-toggle" type="checkbox" '
-            f'data-pos="{i}" data-traces="{sphere_idx},{circle_idx},{points_idx}" {checked}>'
+            f'data-pos="{i}" data-traces="{sphere_idx},{circle_idx}" {checked}>'
             f'2θ ≈ {two_theta}</label>'
         )
     lines.append("</div>")
@@ -1176,15 +1178,15 @@ def _selector_checkbox_html(g_values: list[float], group_indices: list[tuple[int
 
 def _ring_selector_checkbox_html(
     ring_specs: list[tuple[float, float]],
-    ring_groups: list[tuple[int, int, int]],
+    ring_groups: list[tuple[int, int]],
 ) -> str:
     lines = ["<div id=\"g-selector\">"]
-    for i, ((g_r_val, g_z_val), (ring_idx, intersection_idx, points_idx)) in enumerate(
+    for i, ((g_r_val, g_z_val), (ring_idx, intersection_idx)) in enumerate(
         zip(ring_specs, ring_groups, strict=True)
     ):
         lines.append(
             f'<label class="g-option"><input class="g-toggle" type="checkbox" '
-            f'data-pos="{i}" data-traces="{ring_idx},{intersection_idx},{points_idx}" checked>'
+            f'data-pos="{i}" data-traces="{ring_idx},{intersection_idx}" checked>'
             f'|Gᵣ| ≈ {g_r_val:.3f} Å⁻¹, G_z ≈ {g_z_val:.3f} Å⁻¹</label>'
         )
     lines.append("</div>")
@@ -1192,16 +1194,16 @@ def _ring_selector_checkbox_html(
 
 
 def _cylinder_selector_checkbox_html(
-    cylinder_specs: list[float], cylinder_groups: list[tuple[int, int, int, int]]
+    cylinder_specs: list[float], cylinder_groups: list[tuple[int, int, int]]
 ) -> str:
     lines = ["<div id=\"g-selector\">"]
-    for i, (g_r_val, (cyl_idx, intersection_idx, ring_idx, points_idx)) in enumerate(
+    for i, (g_r_val, (cyl_idx, intersection_idx, ring_idx)) in enumerate(
         zip(cylinder_specs, cylinder_groups, strict=True)
     ):
         checked = "checked" if i == 0 else ""
         lines.append(
             f'<label class="g-option"><input class="g-toggle" type="checkbox" '
-            f'data-pos="{i}" data-traces="{cyl_idx},{intersection_idx},{ring_idx},{points_idx}" {checked}>'
+            f'data-pos="{i}" data-traces="{cyl_idx},{intersection_idx},{ring_idx}" {checked}>'
             f'|Gᵣ| ≈ {g_r_val:.3f} Å⁻¹</label>'
         )
     lines.append("</div>")
@@ -1212,17 +1214,17 @@ def build_interactive_page(fig: go.Figure, context: dict) -> str:
     import plotly.io as pio
 
     g_values: list[float] = context["g_values"]
-    g_group_indices: list[tuple[int, int, int]] = context["g_group_indices"]
+    g_group_indices: list[tuple[int, int]] = context["g_group_indices"]
     g_two_thetas: list[str] = context["g_two_thetas"]
     g_ring_specs: list[tuple[float, float]] = context["g_ring_specs"]
     g_ring_indices: list[int] = context["g_ring_indices"]
-    g_ring_groups: list[tuple[int, int, int]] = context["g_ring_groups"]
+    g_ring_groups: list[tuple[int, int]] = context["g_ring_groups"]
     lattice_visibility: list[bool] = context["lattice_visibility"]
     g_sphere_visibility: list[bool] = context["g_sphere_visibility"]
     g_ring_visibility: list[bool] = context["g_ring_visibility"]
     g_cylinder_visibility: list[bool] = context["g_cylinder_visibility"]
     g_cylinder_specs: list[float] = context["g_cylinder_specs"]
-    g_cylinder_groups: list[tuple[int, int, int, int]] = context["g_cylinder_groups"]
+    g_cylinder_groups: list[tuple[int, int, int]] = context["g_cylinder_groups"]
 
     figure_id = "mono-figure"
     figure_html = pio.to_html(


### PR DESCRIPTION
### Motivation
- Improve clarity in the mono simulator by not rendering every individual reciprocal-space point when viewing powder shells, 2D rings, or |Gᵣ| cylinders.  
- Keep the existing shell/ring/cylinder toggles while removing point markers so selectors still control qualitative features rather than cluttered point clouds.

### Description
- Stop including point-marker traces in group tuples by removing point indices from `g_group_indices`, `g_ring_groups`, and `g_cylinder_groups` and adjust related zip shapes in `build_mono_figure` (updates to `g_group_indices`, `g_ring_groups`, `g_cylinder_group_indices`).
- Update selector-generation helpers (`_selector_checkbox_html`, `_ring_selector_checkbox_html`, `_cylinder_selector_checkbox_html`) to expect the smaller group tuples and to emit `data-traces` attributes that no longer include per-point trace indices.
- Force powder-related point traces off in the visibility computation by adding `powder_point_indices` to `_mode_visibility` and defaulting point entries to hidden, and adjust default masks so point markers are not shown in `g_mask_default`/visibility defaults.

### Testing
- Render smoke test: called `build_mono_figure` and `build_interactive_page` with `low_quality=True` and a small frame set to produce an HTML snapshot and verified by capturing a browser screenshot (`mono_simulator_powder_no_points.png`) using Playwright, which completed successfully.  
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff6f9aa208333b53b20bff55b26eb)