### PR TITLE
Disable Plotly legend in mono simulator

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -1091,6 +1091,7 @@ def build_mono_figure(
         ),
         paper_bgcolor="rgba(0,0,0,0)",
         margin=dict(l=0, r=0, b=0, t=0),
+        showlegend=False,
         sliders=sliders,
         updatemenus=[
             dict(


### PR DESCRIPTION
### Motivation
- The interactive mono simulator should not display the Plotly legend to keep the visualization clean and focused on the Ewald sphere and controls.

### Description
- Disable the Plotly legend by setting `showlegend=False` in the figure `layout` within `build_mono_figure` in `mono_simulator.py`.

### Testing
- Generated the HTML via `build_mono_figure` and `build_interactive_page` and saved it to `artifacts/mono_simulator.html`, which succeeded.
- Launched a local server with `python -m http.server 8000` and captured a screenshot of the rendered page using a Playwright script, which produced `artifacts/mono_simulator.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697134b3e1308333b4e4c1fadacff074)