### PR TITLE
Thicken intersection lines across figures

### DIFF
--- a/mono_simulator.py
+++ b/mono_simulator.py
@@ -58,6 +58,7 @@ CYLINDER_POINT_MARKER_SIZE = 12.0
 LATTICE_POINT_MARKER_SIZE = 13.0
 HIT_MARKER_SIZE = 26.0
 HIT_COLOR = "#000000"
+INTERSECTION_LINE_WIDTH = 8
 
 
 def _scaled_opacity(
@@ -837,7 +838,7 @@ def build_mono_figure(
                     y=y_combined,
                     z=z_combined,
                     mode="lines",
-                    line=dict(color=HIT_COLOR, width=7),
+                    line=dict(color=HIT_COLOR, width=INTERSECTION_LINE_WIDTH),
                     showlegend=False,
                     name=f"|Gᵣ| ∩ Ewald ({g_r_val:.3f} Å⁻¹)",
                     visible=visibility,
@@ -894,7 +895,7 @@ def build_mono_figure(
             y=circle[1],
             z=circle[2],
             mode="lines",
-            line=dict(color=HIT_COLOR, width=5),
+            line=dict(color=HIT_COLOR, width=INTERSECTION_LINE_WIDTH),
             showlegend=False,
             name=f"|G| ∩ Ewald ({g_val:.3f} Å⁻¹)",
             visible=visibility,

--- a/mosaic_sim/animation.py
+++ b/mosaic_sim/animation.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 import plotly.graph_objects as go
 
-from .constants import a_hex, c_hex, K_MAG, d_hex
+from .constants import a_hex, c_hex, K_MAG, INTERSECTION_LINE_WIDTH, d_hex
 from .geometry import sphere, rot_x, intersection_circle
 from .intensity import mosaic_intensity
 
@@ -81,7 +81,7 @@ def build_animation(H: int = 0, K: int = 0, L: int = 1,
                              showscale=False, name="Ewald sphere"))
     fig.add_trace(go.Scatter3d(x=ring_x, y=ring_y, z=ring_z,
                                mode="lines",
-                               line=dict(color="green", width=5),
+                               line=dict(color="green", width=INTERSECTION_LINE_WIDTH),
                                name="2θB ring"))
     fig.add_trace(go.Scatter3d(x=[k_tail[0], k_head[0]], y=[k_tail[1], k_head[1]], z=[k_tail[2], k_head[2]],
                                mode="lines", line=dict(color="black", width=5), name="kᵢ"))

--- a/mosaic_sim/constants.py
+++ b/mosaic_sim/constants.py
@@ -11,9 +11,12 @@ c_hex = 28.636e-10
 # Magnitude of the incident wavevector |k|
 K_MAG = 2 * math.pi / λ
 
+# Styling for intersection curves/rings in Plotly figures.
+INTERSECTION_LINE_WIDTH = 8
+
 
 def d_hex(h: int, k: int, l: int, a: float = a_hex, c: float = c_hex) -> float:
     """Return the d-spacing for (h k l) using hexagonal parameters."""
     return 1.0 / math.sqrt((4/3) * (h*h + h*k + k*k) / a**2 + (l / c) ** 2)
 
-__all__ = ["λ", "a_hex", "c_hex", "K_MAG", "d_hex"]
+__all__ = ["λ", "a_hex", "c_hex", "K_MAG", "INTERSECTION_LINE_WIDTH", "d_hex"]

--- a/mosaic_sim/cylinder.py
+++ b/mosaic_sim/cylinder.py
@@ -12,7 +12,7 @@ import math
 import numpy as np
 import plotly.graph_objects as go
 
-from .constants import a_hex, c_hex, K_MAG, d_hex
+from .constants import a_hex, c_hex, K_MAG, INTERSECTION_LINE_WIDTH, d_hex
 from .geometry import (
     sphere,
     rot_x,
@@ -106,7 +106,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
             y=ring_y,
             z=ring_z,
             mode="lines",
-            line=dict(color="red", width=5),
+            line=dict(color="red", width=INTERSECTION_LINE_WIDTH),
             name="Ewald/Bragg overlap",
         )
     )
@@ -131,7 +131,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
             y=cyl_line_y,
             z=cyl_line_z,
             mode="lines",
-            line=dict(color="green", width=5),
+            line=dict(color="green", width=INTERSECTION_LINE_WIDTH),
             name="Cylinder/Ewald overlap",
         )
     )
@@ -143,7 +143,7 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
             y=br_line_y,
             z=br_line_z,
             mode="lines",
-            line=dict(color="orange", width=5),
+            line=dict(color="orange", width=INTERSECTION_LINE_WIDTH),
             name="Cylinder/Bragg overlap",
         )
     )
@@ -257,14 +257,14 @@ def build_cylinder_figure(H: int = 0, K: int = 0, L: int = 12,
                         y=Ly,
                         z=Lz,
                         mode="lines",
-                        line=dict(color="green", width=5),
+                        line=dict(color="green", width=INTERSECTION_LINE_WIDTH),
                     ),
                     go.Scatter3d(
                         x=Bcx,
                         y=Bcy,
                         z=Bcz,
                         mode="lines",
-                        line=dict(color="orange", width=5),
+                        line=dict(color="orange", width=INTERSECTION_LINE_WIDTH),
                     ),
                     go.Scatter3d(
                         x=ax_line_x,

--- a/mosaic_sim/detector.py
+++ b/mosaic_sim/detector.py
@@ -9,7 +9,7 @@ import numpy as np
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
-from .constants import a_hex, c_hex, K_MAG, d_hex
+from .constants import a_hex, c_hex, K_MAG, INTERSECTION_LINE_WIDTH, d_hex
 from .geometry import sphere, rot_x, intersection_circle
 from .intensity import mosaic_intensity
 
@@ -96,7 +96,8 @@ def build_detector_figure(H: int = 0, K: int = 0, L: int = 12,
                              opacity=0.3, colorscale="Blues", showscale=False), 1, 1)
 
     fig.add_trace(go.Scatter3d(x=ring_x, y=ring_y, z=ring_z,
-                               mode="lines", line=dict(color="green", width=5)), 1, 1)
+                               mode="lines",
+                               line=dict(color="green", width=INTERSECTION_LINE_WIDTH)), 1, 1)
 
     k_tail, k_head = np.zeros(3), np.array([0, K_MAG, 0])
     fig.add_trace(go.Scatter3d(x=[0, k_head[0]], y=[0, k_head[1]], z=[0, k_head[2]],
@@ -143,7 +144,7 @@ def build_detector_figure(H: int = 0, K: int = 0, L: int = 12,
                              mode="markers+lines",
                              marker=dict(size=7, color=I_blur0, colorscale="Viridis",
                                          showscale=False, opacity=0.9),
-                             line=dict(width=3, color="grey")), 1, 2)
+                             line=dict(width=INTERSECTION_LINE_WIDTH, color="grey")), 1, 2)
     ring2d_idx = len(fig.data) - 1
     fig.update_xaxes(visible=False, scaleanchor="y", row=1, col=2)
     fig.update_yaxes(visible=False, row=1, col=2)
@@ -172,7 +173,7 @@ def build_detector_figure(H: int = 0, K: int = 0, L: int = 12,
                              mode="markers+lines",
                              marker=dict(size=7, color=I_blur, colorscale="Viridis",
                                          showscale=False, opacity=0.9),
-                             line=dict(width=3, color="grey"))
+                             line=dict(width=INTERSECTION_LINE_WIDTH, color="grey"))
 
         G_dir = np.array([0, math.sin(th), math.cos(th)])
         G_vec = G_dir * G_MAG


### PR DESCRIPTION
### Motivation
- Make intersection/ring lines in the visualizations thicker so they are easier to see and edit.
- Centralize the styling so the intersection line width can be changed in one place rather than scattered literals.

### Description
- Added a shared constant `INTERSECTION_LINE_WIDTH` in `mosaic_sim/constants.py` to hold the line width for intersection curves. 
- Replaced hard-coded intersection widths with `INTERSECTION_LINE_WIDTH` in `mosaic_sim/animation.py`, `mosaic_sim/cylinder.py`, and `mosaic_sim/detector.py` so the ring/overlap traces use the thicker styling. 
- Added `INTERSECTION_LINE_WIDTH` to `mono_simulator.py` and updated its intersection/circle traces to use the same wider width for consistency. 
- Updated `__all__` in `mosaic_sim/constants.py` and adjusted imports where needed to expose and consume the new symbol.

### Testing
- No automated tests were executed for this change; edits were limited to plotting styling and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbf57f1048333b6a7b884e67d363c)